### PR TITLE
Bug with string field type

### DIFF
--- a/src/deercreeklabs/lancaster/pcf_utils.cljc
+++ b/src/deercreeklabs/lancaster/pcf_utils.cljc
@@ -157,7 +157,7 @@
 
     (string? avro-schema)
     (if (u/avro-primitive-type-strings avro-schema)
-      :primitive
+      :primitive-string
       :name-string)
 
     (sequential? avro-schema)
@@ -183,6 +183,10 @@
 (defmulti avro-schema->edn-schema pcf-type-dispatch)
 
 (defmethod avro-schema->edn-schema :primitive
+  [avro-schema]
+  (keyword (:type avro-schema)))
+
+(defmethod avro-schema->edn-schema :primitive-string
   [avro-schema]
   (keyword avro-schema))
 


### PR DESCRIPTION
Minimum bug example:

``` clj
(def string-minimal-example-pcf
  "{\"type\":\"record\",\"name\":\"StringMinimalExample\",\"namespace\":\"com.piotr-yuxuan\",\"fields\":[{\"name\":\"someOtherField\",\"type\":[\"null\",\"long\"]},{\"name\":\"url\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"}}]}")

(deercreeklabs.lancaster.pcf-utils/pcf->edn-schema (str StringMinimalExample/SCHEMA$))
=> Syntax error compiling at …
   Schema argument to get-avro-type is nil.
```

The previous expression fails silently because `(keyword {:type
"string"}) => nil`. With this fix, its output becomes:

``` clj
{:type :record,
 :name :string-minimal-example,
 :namespace "com.piotr-yuxuan",
 :fields [{:name :some-other-field, :type [:null :long], :default nil}
          {:name :url, :type :string, :default ""}]}
```

which is what we're likely to expect.