### PR TITLE
Fix issue #7

### DIFF
--- a/test/deercreeklabs/unit/namespaced_json_test.clj
+++ b/test/deercreeklabs/unit/namespaced_json_test.clj
@@ -1,0 +1,20 @@
+(ns deercreeklabs.unit.namespaced-json-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [deercreeklabs.lancaster :as l]))
+
+(deftest test-namespaced-enums-from-json
+  (let [schema (l/json->schema (slurp "test/namespaced_enums.json"))
+        obj {:foo :foo-x :bar :foo-y}]
+    (is (= :test-namespaced-enums (get-in schema [:edn-schema :name])))
+    (is (= [2 0 2 2]
+           (map int (l/serialize schema obj))))
+    (is (= obj (l/deserialize-same schema (l/serialize schema obj))))))
+
+(deftest test-namespaced-records-from-json
+  (let [schema (l/json->schema (slurp "test/namespaced_records.json"))
+        obj {:foo {:baz "a string"} :bar {}}]
+    (is (= :test-namespaced-records (get-in schema [:edn-schema :name])))
+    (is (= [2, 2, 16, 97, 32, 115, 116, 114, 105, 110, 103, 2, 0]
+           (map int (l/serialize schema obj))))
+    (is (= obj (l/deserialize-same schema (l/serialize schema obj))))))

--- a/test/namespaced_enums.json
+++ b/test/namespaced_enums.json
@@ -1,0 +1,19 @@
+{
+  "type" : "record",
+  "name" : "TestNamespacedEnums",
+  "namespace" : "com.company",
+  "fields" : [ {
+    "name" : "foo",
+    "type" : [ "null", {
+      "type" : "enum",
+      "name" : "FooEnum",
+      "namespace": "com.company",
+      "symbols" : [ "FOO_X", "FOO_Y", "FOO_Z" ]
+    } ],
+    "default" : null
+  }, {
+    "name" : "bar",
+    "type" : [ "null", "com.company.FooEnum" ],
+    "default" : null
+  } ]
+}

--- a/test/namespaced_records.json
+++ b/test/namespaced_records.json
@@ -1,0 +1,24 @@
+{
+  "type" : "record",
+  "name" : "TestNamespacedRecords",
+  "namespace" : "com.company",
+  "fields" : [ {
+    "name" : "foo",
+    "type" : [ "null", {
+      "type" : "record",
+      "name" : "FooRecord",
+      "namespace": "com.company",
+      "fields": [
+        {
+          "type": ["null", "string"],
+          "name": "baz"
+        }
+      ]
+    } ],
+    "default" : null
+  }, {
+    "name" : "bar",
+    "type" : [ "null", "com.company.FooRecord" ],
+    "default" : null
+  } ]
+}


### PR DESCRIPTION
...where namespaced enums and records are not properly stored in name->* maps so they cant be referenced by namespaced names in serailization and and deserialization.

Also:
- Collapses all cases of this in `utils.cljc` to use `swap-named-value!` to handle these namespaces.
- Adds 2 test cases to verify this.
- Adds an informative error when a name that isn't in the `name->serializer` map. (Used to be NullPointerException)