### PR TITLE
Update the namespaced names to handle enclosing namespaces

### DIFF
--- a/test/deercreeklabs/unit/namespaced_json_test.clj
+++ b/test/deercreeklabs/unit/namespaced_json_test.clj
@@ -13,8 +13,38 @@
 
 (deftest test-namespaced-records-from-json
   (let [schema (l/json->schema (slurp "test/namespaced_records.json"))
-        obj {:foo {:baz "a string"} :bar {}}]
+        obj {:foo {:baz "a string"
+                   :subfoo {:x 1}
+                   :subfoofoo {:x 2}} :bar {}}]
     (is (= :test-namespaced-records (get-in schema [:edn-schema :name])))
-    (is (= [2, 2, 16, 97, 32, 115, 116, 114, 105, 110, 103, 2, 0]
+    (is (= #{:long
+             :double
+             :com.company/test-namespaced-records
+             :int
+             :sub-foo-record
+             :float
+             :com.company/foo-record
+             :string
+             :null
+             :test-namespaced-records
+             :com.company/sub-foo-record
+             :bytes
+             :foo-record
+             :boolean} (set (keys (get-in schema [:name->edn-schema])))))
+    (is (= #{:long
+             :double
+             :com.company/test-namespaced-records
+             :int
+             :sub-foo-record
+             :float
+             :com.company/foo-record
+             :string
+             :null
+             :test-namespaced-records
+             :com.company/sub-foo-record
+             :bytes
+             :foo-record
+             :boolean} (set (keys @(get-in schema [:*name->serializer])))))
+    (is (= '(2 2 16 97 32 115 116 114 105 110 103 2 2 2 2 2 4 2 0 0 0)
            (map int (l/serialize schema obj))))
     (is (= obj (l/deserialize-same schema (l/serialize schema obj))))))

--- a/test/namespaced_records.json
+++ b/test/namespaced_records.json
@@ -12,6 +12,26 @@
         {
           "type": ["null", "string"],
           "name": "baz"
+        },
+        {
+          "name": "subfoo",
+          "type": ["null",
+                   {
+                     "type": "record",
+                     "name": "SubFooRecord",
+                     "fields": [
+                       {
+                         "type": ["null", "int"],
+                         "name": "x"
+                       }
+                     ]
+                   }
+                  ]
+        },
+        {
+          "name": "subfoofoo",
+          "type": ["null",
+                  "com.company.SubFooRecord"]
         }
       ]
     } ],


### PR DESCRIPTION
This is a follow-up to #7/#8 to handle enclosing namespaces. I reuse the `**enclosing-namespace**` dynamic variable to pass down enclosing namespaces from records and arrays to the eventual use in `swap-named-value!`. This happens from `get-schemas!` and `make-serializer`.

I also updated the test to check this case. Notice how `SubFooRecord` has no namespace, but should be annotated with `com.company` because it is within `com.company/FooRecord` in `test/namespaced_records.json`.