### PR TITLE
handle java namespaces in the namespace reference system

### DIFF
--- a/src/deercreeklabs/lancaster/utils.cljc
+++ b/src/deercreeklabs/lancaster/utils.cljc
@@ -595,7 +595,7 @@
   [*atom edn-schema value]
   (let [name (:name edn-schema)]
     (swap! *atom assoc (:name edn-schema) value)
-    (when-let [ns (or (:namespace edn-schema) (namespace name) **enclosing-namespace**)]
+    (when-let [ns (java-namespace->clj-namespace (or (:namespace edn-schema) (namespace name) **enclosing-namespace**))]
       (swap! *atom assoc (keyword ns (clojure.core/name name)) value))))
 
 (defmethod make-serializer :null

--- a/test/deercreeklabs/unit/namespaced_json_test.clj
+++ b/test/deercreeklabs/unit/namespaced_json_test.clj
@@ -23,11 +23,11 @@
              :int
              :sub-foo-record
              :float
-             :com.company/foo-record
+             :com.company.foo-bar/foo-record
              :string
              :null
              :test-namespaced-records
-             :com.company/sub-foo-record
+             :com.company.foo-bar/sub-foo-record
              :bytes
              :foo-record
              :boolean} (set (keys (get-in schema [:name->edn-schema])))))
@@ -37,11 +37,11 @@
              :int
              :sub-foo-record
              :float
-             :com.company/foo-record
+             :com.company.foo-bar/foo-record
              :string
              :null
              :test-namespaced-records
-             :com.company/sub-foo-record
+             :com.company.foo-bar/sub-foo-record
              :bytes
              :foo-record
              :boolean} (set (keys @(get-in schema [:*name->serializer])))))

--- a/test/namespaced_records.json
+++ b/test/namespaced_records.json
@@ -7,7 +7,7 @@
     "type" : [ "null", {
       "type" : "record",
       "name" : "FooRecord",
-      "namespace": "com.company",
+      "namespace": "com.company.foo_bar",
       "fields": [
         {
           "type": ["null", "string"],
@@ -31,14 +31,14 @@
         {
           "name": "subfoofoo",
           "type": ["null",
-                  "com.company.SubFooRecord"]
+                  "com.company.foo_bar.SubFooRecord"]
         }
       ]
     } ],
     "default" : null
   }, {
     "name" : "bar",
-    "type" : [ "null", "com.company.FooRecord" ],
+    "type" : [ "null", "com.company.foo_bar.FooRecord" ],
     "default" : null
   } ]
 }


### PR DESCRIPTION
Continuing on the namespace fixes as I encounter issues with them. This one happens when a namespace with an underscore is parsed from json, the type gets converted to Clojure kebab case, but the name-> reference key does not. This PR fixes that and adjusts the namespace tests to test it.