### PR TITLE
fix pcf for namespaced records

### DIFF
--- a/src/deercreeklabs/lancaster/pcf_utils.cljc
+++ b/src/deercreeklabs/lancaster/pcf_utils.cljc
@@ -33,7 +33,7 @@
 
 (defmethod filter-attrs :record
   [sch]
-  (-> (select-keys sch [:type :name :fields])
+  (-> (select-keys sch [:type :name :namespace :fields])
       (update :fields fix-field-attrs)))
 
 (defmethod filter-attrs :union
@@ -47,7 +47,7 @@
     sch))
 
 (defn emit-field [field]
-  (let [{:keys [name type]} field]
+  (let [{:keys [name type namespace]} field]
     (str "{\"name\":\"" name "\",\"type\":" (emit type) "}")))
 
 (defn emit-fields [fields]
@@ -101,7 +101,11 @@
 
 (defmethod emit :record
   [sch]
-  (let [{:keys [name fields]} sch
+  (let [{:keys [name namespace fields]} sch
+        name (cond (re-find #"\." name) name
+                   namespace (str (u/clj-namespace->java-namespace namespace) "." name)
+                   u/**enclosing-namespace** (str u/**enclosing-namespace** "." name)
+                   :else name)
         sch-ns (u/fullname->ns name)
         name-pair (str "\"name\":\"" name "\"")
         type-pair (str "\"type\":\"record\"")

--- a/test/deercreeklabs/unit/namespaced_json_test.clj
+++ b/test/deercreeklabs/unit/namespaced_json_test.clj
@@ -1,7 +1,10 @@
 (ns deercreeklabs.unit.namespaced-json-test
   (:require
    [clojure.test :refer [deftest is]]
-   [deercreeklabs.lancaster :as l]))
+   [cheshire.core :as json]
+   [deercreeklabs.lancaster :as l])
+  (:import org.apache.avro.Schema$Parser
+           org.apache.avro.SchemaNormalization))
 
 (deftest test-namespaced-enums-from-json
   (let [schema (l/json->schema (slurp "test/namespaced_enums.json"))
@@ -48,3 +51,11 @@
     (is (= '(2 2 16 97 32 115 116 114 105 110 103 2 2 2 2 2 4 2 0 0 0)
            (map int (l/serialize schema obj))))
     (is (= obj (l/deserialize-same schema (l/serialize schema obj))))))
+
+(deftest test-namespaced-schema-pcf
+  (is (= (SchemaNormalization/toParsingForm
+          (.parse (Schema$Parser.)
+                  (slurp "test/namespaced_records.json")))
+         (l/pcf
+          (l/json->schema
+           (slurp "test/namespaced_records.json"))))))


### PR DESCRIPTION
More namespace fixes. This one fixes the PCF for namespaced records. I added a test using the avro library to ensure that the `l/pcf` matches `SchemaNormalization.parsingForm()`. Then I fixed the namespace handling in `pcf_utils.clj` to handle namespaces correctly, including enclosing namespaces and java conversion.