### PR TITLE
remove outer wrapping throw exception

### DIFF
--- a/src/deercreeklabs/lancaster.cljc
+++ b/src/deercreeklabs/lancaster.cljc
@@ -166,15 +166,7 @@
                     {:ba ba
                      :ba-type (#?(:clj class :cljs type) ba)})))
   (let [is (impl/input-stream ba)]
-    (try
-      (u/deserialize reader-schema writer-schema is)
-      (catch #?(:clj Exception :cljs js/Error) e
-        (throw (ex-info
-                (str "Serialized data in byte array does not match "
-                     "given writer schema.")
-                {:writer-edn-schema (u/pprint-str
-                                     (u/edn-schema writer-schema))
-                 :orig-e e}))))))
+    (u/deserialize reader-schema writer-schema is)))
 
 (s/defn deserialize-same :- s/Any
   "Deserializes Avro-encoded data from a byte array, using the given schema

--- a/test/deercreeklabs/unit/evolution_test.cljc
+++ b/test/deercreeklabs/unit/evolution_test.cljc
@@ -101,12 +101,10 @@
         writer-schema lt/fish-or-person-or-dog-v2-schema
         reader-schema lt/person-or-dog-schema
         encoded (l/serialize writer-schema data)]
-    (try
-      (l/deserialize reader-schema writer-schema encoded)
-      (is (= :did-not-throw :but-should-have))
-      (catch #?(:clj Exception :cljs js/Error) e
-        (let [msg (u/ex-msg e)]
-          (is (str/includes? msg "does not match")))))))
+    (is (thrown-with-msg?
+          #?(:clj ExceptionInfo :cljs js/Error)
+          #"do not match."
+          (l/deserialize reader-schema writer-schema encoded)))))
 
 (deftest test-schema-evolution-no-match
   (let [data {:sku 123
@@ -116,7 +114,7 @@
         encoded (l/serialize writer-schema data)]
     (is (thrown-with-msg?
          #?(:clj ExceptionInfo :cljs js/Error)
-         #"does not match."
+         #"do not match."
          (l/deserialize reader-schema writer-schema encoded)))))
 
 (deftest test-schema-evolution-named-ref


### PR DESCRIPTION
I'm not sure this is the right thing to do but it allows me to bring it up.

```clojure
  ;; First I'll make some data and a schema.

(def data-0 {:intro-text ["This is" "my intro text"]})

(def intro-text-schema (l/array-schema l/string-schema))

(l/def-record-schema proposal-schema-0
  [:intro-text intro-text-schema])

(def bytes-0 (l/serialize proposal-schema-0 data-0))
(l/deserialize proposal-schema-0 proposal-schema-0 bytes-0)
;; => {:intro-text ["This is" "my intro text"]}

;; So far so good.

;; Now I'll make some new data and a new version of my
;; schema that has a different name.

(def data-1 {:intro-text {:lines ["This is" "my first rich text"]
                          :is-bold true}})

(l/def-record-schema intro-text-rich-schema
  [:lines (l/array-schema l/string-schema)]
  [:is-bold l/boolean-schema])

;; Note that the schema name here is foo not proposal.
(l/def-record-schema foo-schema
  [:intro-text intro-text-rich-schema])

(def bytes-foo (l/serialize foo-schema data-1))
(l/deserialize foo-schema foo-schema bytes-1)
;; => {:intro-text {:lines ["This is" "my first rich text"], :is-bold true}}

;; No surprise there.

;; Now I'll see if my schema change is backwards compatible. I happen to know
;; already that it's not. The reader and write schema are incompatible. (I also
;; learned recently that the schema names need to match (after reading the
;; Avro spec I think it's more accurate to say that the record names need to
;; match) but I'm replicating that learning experience here to demonstrate
;; something.) Let's see what happens.

;; Can new code read old data?
(l/deserialize foo-schema proposal-schema-0 bytes-0)
;; This errors with the message
;; "Serialized data in byte array does not match given writer schema."

;; What? Of course the byte array matches the writer schema, I just defined it
;; a few lines above. Something fishy! After some digging I see there are some
;; "original exceptions" underneath.
(-> *e ex-data :orig-e ex-data :orig-e ex-message)
;; => "Schema names do not match. (:user/proposal != :user/foo)"

;; Now that makes sense. Let's make the schema names match. Anything after
;; "-schema" is stripped off so I can achive this with the following.
(l/def-record-schema proposal-schema-1
  [:intro-text intro-text-rich-schema])

(l/deserialize proposal-schema-1 proposal-schema-0 bytes-0)
;; => "Serialized data in byte array does not match given writer schema."

;; What? Of course the byte array matches the writer schema, I just defined it
;; a few lines above. Something fishy! Let's check out those original exceptions
;; again.

(-> *e ex-data :orig-e ex-data :orig-e ex-message)
;; => "No schemas in reader union schema match writer."

;; Now that's the error I expected at the beginning.
```
I go digging into this and I discover that [this try block](https://github.com/deercreeklabs/lancaster/blob/master/src/deercreeklabs/lancaster.cljc#L169) is, as I understand it, relabeling any exception with this misleading message. The first `:orig-e` I'm passing by above is [thrown here](https://github.com/deercreeklabs/lancaster/blob/master/src/deercreeklabs/lancaster/schemas.cljc#L51) and is from what I can tell accurate but not fully descriptive. The descriptive errors I wanted are defined [here (mismatched names)](https://github.com/deercreeklabs/lancaster/blob/master/src/deercreeklabs/lancaster/deser.cljc#L16) and [here (reader union lacks match)](https://github.com/deercreeklabs/lancaster/blob/master/src/deercreeklabs/lancaster/deser.cljc#L343).

My "fix" here is to remove the outer most wrapping throw that was so misleading to me. Am I correct that it's misleading or do I misunderstand something? Is this pattern of wrapping throws with throws and `:orig-e`'s that get more specific as you drill down a common pattern?