### PR TITLE
Bug

### DIFF
--- a/src/deercreeklabs/lancaster/sub.cljc
+++ b/src/deercreeklabs/lancaster/sub.cljc
@@ -80,16 +80,6 @@
                             (reduced field*)
                             acc))
                         nil (:fields edn-schema))]
-      (when (= {:name :deercreeklabs.unit.sub-test/tree,
-                :type :record,
-                :fields
-                [{:name :value, :type [:null :int], :default nil}
-                 {:name :right,
-                  :type [:null :deercreeklabs.unit.sub-test/tree],
-                  :default nil}
-                 {:name :left,
-                  :type [:null :deercreeklabs.unit.sub-test/tree],
-                  :default nil}]} edn-schema))
       (when field
         (let [child (-> (:type field)
                         (expand-name-kws name->edn-schema))]
@@ -165,7 +155,8 @@
         sub-edn-schema (edn-schema-at-path top-edn-schema path 0
                                            name->edn-schema)]
     (when sub-edn-schema
-      (schemas/edn-schema->lancaster-schema sub-edn-schema))))
+      (-> (expand-name-kws sub-edn-schema name->edn-schema)
+          (schemas/edn-schema->lancaster-schema)))))
 
 (defn member-schemas [schema]
   (let [{:keys [edn-schema name->edn-schema]} schema

--- a/test/deercreeklabs/unit/sub_test.cljc
+++ b/test/deercreeklabs/unit/sub_test.cljc
@@ -179,7 +179,7 @@
 (def c
   {:bb [{:z "test"} {:z "another"}]})
 
-(deftest test-schema-at-path-expansion-deeper-than-path-nesting
+(deftest test-schema-at-path-name-expansion-deeper-than-path-nesting
   (let [schema (l/schema-at-path root-schema [:c])]
     (is (lt/round-trip? schema c))))
 

--- a/test/deercreeklabs/unit/sub_test.cljc
+++ b/test/deercreeklabs/unit/sub_test.cljc
@@ -159,6 +159,30 @@
                                  [:children 0 :children 1 :children])]
     (is (lt/round-trip? schema [ralph]))))
 
+(l/def-record-schema z-schema
+  [:z l/string-schema])
+
+(def d-schema
+  (l/array-schema z-schema))
+
+(l/def-record-schema a-schema
+  [:aa d-schema])
+
+(l/def-record-schema b-schema
+  [:bb d-schema])
+
+(l/def-record-schema root-schema
+  [:a a-schema]
+  [:b b-schema]
+  [:c b-schema])
+
+(def c
+  {:bb [{:z "test"} {:z "another"}]})
+
+(deftest test-schema-at-path-expansion-deeper-than-path-nesting
+  (let [schema (l/schema-at-path root-schema [:c])]
+    (is (lt/round-trip? schema c))))
+
 (deftest test-schema-at-path-evolution
   (is (nil? (l/schema-at-path sys-state-schema [:new-state-field])))
   (is (nil? (l/schema-at-path sys-state-schema [::msgs 0 :new-msg-field]))))


### PR DESCRIPTION
The recursion in `schema-at-path` is only as deep as the path you pass in. In the test case the path is `[:c]` but the name expansion that needs to happen is actually 2 levels deep since at `[:c]` you have a `:b` (which gets expanded during the `edn-schema-at-path` recursion. But inside `:b` you have a `:z` that needs expanding but `edn-schema-at-path` exits recursion when `(>= i (count path))`. So we are left needing, in this case, one more call to expand names. This PR adds another recursive call to expanding names after `edn-schema-at-path`.