### PR TITLE
GraalVM compatibility: using multi-segment namespaces of primitive-math

### DIFF
--- a/src/deercreeklabs/lancaster/impl.clj
+++ b/src/deercreeklabs/lancaster/impl.clj
@@ -9,7 +9,7 @@
    (java.io ByteArrayInputStream ByteArrayOutputStream)
    (java.math BigInteger)))
 
-(primitive-math/use-primitive-operators)
+(clj-commons.primitive-math/use-primitive-operators)
 
 (defrecord OutputStream [baos ledos]
   u/IOutputStream

--- a/src/deercreeklabs/lancaster/schemas.cljc
+++ b/src/deercreeklabs/lancaster/schemas.cljc
@@ -8,7 +8,7 @@
    [deercreeklabs.lancaster.impl :as impl]
    [deercreeklabs.lancaster.pcf-utils :as pcf-utils]
    [deercreeklabs.lancaster.utils :as u]
-   #?(:clj [primitive-math :as pm])
+   #?(:clj [clj-commons.primitive-math :as pm])
    [schema.core :as s :include-macros true]))
 
 #?(:clj (pm/use-primitive-operators))

--- a/src/deercreeklabs/lancaster/utils.cljc
+++ b/src/deercreeklabs/lancaster/utils.cljc
@@ -8,7 +8,7 @@
    [clojure.string :as str]
    [deercreeklabs.baracus :as ba]
    #?(:cljs [goog.math :as gm])
-   #?(:clj [primitive-math :as pm])
+   #?(:clj [clj-commons.primitive-math :as pm])
    #?(:clj [puget.printer :refer [cprint-str]])
    [schema.core :as s])
   #?(:cljs


### PR DESCRIPTION
Hey Chad,

We are using Lancaster as a CLI application, but the official JVM is terribly slow when it comes to start-up time. Therefeore we'd like to compile a native image using GraalVM, which boots hundreds times faster.

Lancaster causes an issue in the compilation process though. It uses a single-segment namespace from the primitive-math library (which I'm told is only there for backward compatibility), which doesn't fare well with GraalVM. Lucky enough, the 1.0.0 version of the library being used includes a multi-segment version as well. All that is needed to switch is to change the references, as I've done in this commit.

As far as I know, single-segment namespaces are bad practice anyways, so there's only gain here I think? Let me know what you think :).


Bart