### PR TITLE
fix bug in schema evolution for records using name keywords

### DIFF
--- a/src/deercreeklabs/lancaster/utils.cljc
+++ b/src/deercreeklabs/lancaster/utils.cljc
@@ -1785,10 +1785,12 @@
              reader-fields :fields} reader-edn-schema]
         (and (= writer-name reader-name)
              (reduce (fn [acc field-name]
-                       (let [w-field (some #(when (= field-name (:name %)) %)
+                       (let [w-field (or (some #(when (= field-name (:name %)) %)
                                            writer-fields)
-                             r-field (some #(when (= field-name (:name %)) %)
-                                           reader-fields)]
+                                         {:type :null})
+                             r-field (or (some #(when (= field-name (:name %)) %)
+                                           reader-fields)
+                                         {:type :null})]
                          (if (edn-schemas-match? (:type w-field) (:type r-field)
                                                  writer-name->edn-schema
                                                  reader-name->edn-schema)


### PR DESCRIPTION
Under certain conditions, I think when you have a record using name keyword schema references, it reduces over the union of all the fields to make sure the schemas match. However in the compatible evolution case one of them doesn't have that field so you end up with a nil. I think semantically this is the same as allowing :type :null, so I do that instead of returning nil since having nil crashes.

EDIT: I added unit tests that fail without these changes and pass with them. All the other unit tests still pass.